### PR TITLE
Add react-router-dom to non-dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "popper.js": "^1.14.7",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3"
   },
   "scripts": {


### PR DESCRIPTION
To be honest, it makes sense that the last change didn't work. It just changed version strings. I think this should almost 100% fix our heroku deployment.

@triv202 @texzone please review